### PR TITLE
Call the command line to overcome libgit2 limitations related to refspecs

### DIFF
--- a/R/browse.R
+++ b/R/browse.R
@@ -214,8 +214,17 @@ remote_repo <- function(repo, remote) {
     remote <- getOption("browse.remote.default")
   }
 
-  remote_data <- git2r::remote_url(repo, remote) %>%
-    parse_remote_url()
+  remote_data <- try(
+    git2r::remote_url(repo, remote) %>%
+      parse_remote_url(),
+    silent = TRUE
+  )
+
+  if (inherits(remote_data, "try-error")) {
+    remotes <- read.table(text = system("git remote -vv", intern = TRUE))
+    remote_data <- remotes[remotes$V3 == "(push)", 2] %>%
+      parse_remote_url()
+  }
 
   head <- git2r::repository_head(repo)
 


### PR DESCRIPTION
The root of the issue is https://github.com/libgit2/libgit2/issues/1125, where I create to find the remote url of repos that contain refspecs with `*`s. This work-around avoids `git2r` (which uses `libgit2) by calling the command line git directory and parses the output. 